### PR TITLE
feat: add multi-platform publishing with Facebook support

### DIFF
--- a/src/facebook/facebookPage.ts
+++ b/src/facebook/facebookPage.ts
@@ -1,0 +1,219 @@
+import axios, { AxiosResponse } from "axios";
+import { AbstractPublisher } from "../publishers/AbstractPublisher";
+import {
+  CollectedNewsData,
+  ContentLanguage,
+  FormattedNewsData,
+  NewsItem,
+  ProcessedNews,
+} from "../types";
+import { getEmojiForNewsItem, Strings } from "../formatting";
+
+export interface FacebookPostOptions {
+  caption?: string;
+  altText?: string;
+  published?: boolean;
+}
+
+interface FacebookErrorResponse {
+  error: {
+    message: string;
+    type: string;
+    code: number;
+  };
+}
+
+interface FacebookPostResponse {
+  id: string;
+  post_id?: string;
+}
+
+export class FacebookPage extends AbstractPublisher {
+  private accessToken: string;
+  private baseUrl = "https://graph.facebook.com/v19.0";
+
+  constructor() {
+    super();
+    // read access token from environment variable
+    if (!process.env.FACEBOOK_ACCESS_TOKEN) {
+      throw new Error("FACEBOOK_ACCESS_TOKEN is not set");
+    }
+    this.accessToken = process.env.FACEBOOK_ACCESS_TOKEN;
+  }
+
+  async setup(): Promise<void> {
+    // No-op for Facebook since it uses stateless HTTP requests
+    // No persistent connections to clean up
+  }
+
+  async postPhotoWithCaption(
+    pageId: string,
+    photoBuffer: Buffer,
+    options: FacebookPostOptions = {}
+  ): Promise<FacebookPostResponse> {
+    const { caption = "", altText, published = true } = options;
+
+    try {
+      const formData = new FormData();
+
+      // Create a blob from buffer for FormData - convert Buffer to Uint8Array
+      const uint8Array = new Uint8Array(photoBuffer);
+      const blob = new Blob([uint8Array], { type: "image/jpeg" });
+      formData.append("source", blob, "photo.jpg");
+      formData.append("caption", caption);
+      formData.append("published", published.toString());
+      formData.append("access_token", this.accessToken);
+
+      if (altText) {
+        formData.append("alt_text_custom", altText);
+      }
+
+      const response: AxiosResponse<
+        FacebookPostResponse | FacebookErrorResponse
+      > = await axios.post(`${this.baseUrl}/${pageId}/photos`, formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
+
+      if ("error" in response.data) {
+        throw new Error(`Facebook API Error: ${response.data.error.message}`);
+      }
+
+      console.log(
+        `Successfully posted photo to Facebook Page ${pageId}:`,
+        response.data.id
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Error posting to Facebook Page:", error);
+      throw error;
+    }
+  }
+
+  async postTextOnly(
+    pageId: string,
+    message: string
+  ): Promise<FacebookPostResponse> {
+    try {
+      const response: AxiosResponse<
+        FacebookPostResponse | FacebookErrorResponse
+      > = await axios.post(`${this.baseUrl}/${pageId}/feed`, {
+        message: message,
+        access_token: this.accessToken,
+      });
+
+      if ("error" in response.data) {
+        throw new Error(`Facebook API Error: ${response.data.error.message}`);
+      }
+
+      console.log(
+        `Successfully posted text to Facebook Page ${pageId}:`,
+        response.data.id
+      );
+      return response.data;
+    } catch (error) {
+      console.error("Error posting text to Facebook Page:", error);
+      throw error;
+    }
+  }
+
+  static async validateAccessToken(accessToken: string): Promise<boolean> {
+    try {
+      const response = await axios.get(`https://graph.facebook.com/v19.0/me`, {
+        params: {
+          access_token: accessToken,
+        },
+      });
+
+      return response.status === 200 && response.data.id;
+    } catch (error) {
+      console.error("Invalid Facebook access token:", error);
+      return false;
+    }
+  }
+
+  static async getPageInfo(pageId: string, accessToken: string): Promise<any> {
+    try {
+      const response = await axios.get(
+        `https://graph.facebook.com/v19.0/${pageId}`,
+        {
+          params: {
+            fields: "name,id,category",
+            access_token: accessToken,
+          },
+        }
+      );
+
+      if (response.data.error) {
+        throw new Error(`Facebook API Error: ${response.data.error.message}`);
+      }
+
+      return response.data;
+    } catch (error) {
+      console.error("Error getting Facebook page info:", error);
+      throw error;
+    }
+  }
+
+  // AbstractPublisher implementation
+  async publishNews(
+    channelId: string,
+    banner: Buffer,
+    text: string
+  ): Promise<string> {
+    // Note: channelId parameter is ignored since FacebookPage already has pageId in constructor
+    // This allows for consistent interface while maintaining Facebook's constructor pattern
+    const result = await this.postPhotoWithCaption(channelId, banner, {
+      caption: text,
+      published: true,
+    });
+    return result.id;
+  }
+
+  async destroy(): Promise<void> {
+    // No-op for Facebook since it uses stateless HTTP requests
+    // No persistent connections to clean up
+  }
+
+  formatNews(
+    newsData: ProcessedNews,
+    language: ContentLanguage
+  ): FormattedNewsData {
+    const { newsResponse, date, numberOfPosts, numberOfSources } = newsData;
+    const newsItems = newsResponse.newsItems;
+
+    if (newsItems.length === 0) {
+      return {
+        message: "",
+        newsItems: [],
+      };
+    }
+
+    const lang = Strings[language];
+    const header = `${lang.DailyBriefingForDay} ${date}`;
+
+    // Facebook posts have a larger character limit (63,206 characters) but shorter posts perform better
+    // We'll format for better readability on Facebook
+    const formattedItems = newsItems.map((item: NewsItem, index: number) => {
+      const summary =
+        language === "arabic" ? item.summaryArabic : item.summaryEnglish;
+      const emoji = getEmojiForNewsItem(item);
+
+      // Simple numbered format for Facebook
+      return `${index + 1}. ${emoji} ${summary}`;
+    });
+
+    const footer = lang.ProcessedThisManyPostsFromThisManySources.replace(
+      "{numberOfPosts}",
+      numberOfPosts.toString()
+    ).replace("{numberOfSources}", numberOfSources.toString());
+
+    const message = [header, "", ...formattedItems, "", footer].join("\n");
+
+    return {
+      message,
+      newsItems,
+    };
+  }
+}

--- a/src/formatting/emojis.ts
+++ b/src/formatting/emojis.ts
@@ -1,0 +1,33 @@
+import { NewsItem } from "../types";
+
+export const labelEmojis = {
+  president: "🏛️",
+  "foreign-affairs": "🌍",
+  "security-incident": "🚨",
+  "defense-incident": "⚔️",
+  aid: "🤝",
+  infrastructure: "🏢",
+  education: "🎓",
+  "government-services": "🔧",
+  health: "🏥",
+  economy: "💰",
+  environment: "🌍",
+  technology: "💻",
+  culture: "🎭",
+  sports: "🏆",
+  politics: "🎤",
+  business: "💼",
+  science: "🔬",
+  entertainment: "🎥",
+  travel: "🌏",
+  food: "🍔",
+};
+
+export function getEmojiForNewsItem(item: NewsItem): string {
+  // Get the label with the highest relation score
+  const topLabel = item.labels.reduce((prev, current) =>
+    prev.relationScore > current.relationScore ? prev : current
+  );
+
+  return labelEmojis[topLabel.label] || "📰";
+}

--- a/src/formatting/index.ts
+++ b/src/formatting/index.ts
@@ -12,3 +12,7 @@ export const Formatters: Record<
 > = {
   telegram: telegramNewsFormatter,
 };
+
+export { Strings } from "./strings";
+export { measureTelegramRenderedHtml } from "./measureTelegramRenderedHtml";
+export { labelEmojis, getEmojiForNewsItem } from "./emojis";

--- a/src/lambda/Publish.ts
+++ b/src/lambda/Publish.ts
@@ -1,24 +1,20 @@
 import { EventBridgeHandler } from "aws-lambda";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import {
-  ProcessedNewsSchema,
   ContentLanguage,
   ContentLanguages,
+  ProcessedNewsSchema,
+  SupportedPublishChannel,
+  SupportedPublishChannels,
 } from "../types";
-import { prioritizeAndFormat } from "../prioritizeAndFormat";
 import { getMostFrequentLabel } from "../mostFrequentLabel";
-import { TelegramUser } from "../telegram/user";
+import { createPublisher } from "../publishers";
 import { addDateToBanner } from "../banner/newsBanner";
+import { prioritizeNews } from "../prioritizeNews";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION || "us-east-1",
 });
-
-if (!process.env.TELEGRAM_CHANNEL_ID) {
-  throw new Error("TELEGRAM_CHANNEL_ID is not set");
-}
-
-const CHANNEL_ID = process.env.TELEGRAM_CHANNEL_ID;
 
 if (!process.env.CONTENT_LANGUAGE) {
   throw new Error("CONTENT_LANGUAGE is not set");
@@ -32,12 +28,29 @@ if (
 
 const CONTENT_LANGUAGE = process.env.CONTENT_LANGUAGE as ContentLanguage;
 
-let CHANNEL_ID_NUMBER: number;
+if (!process.env.CHANNEL_TYPE) {
+  throw new Error("CHANNEL_TYPE is not set");
+}
 
-if (isNaN(parseInt(CHANNEL_ID))) {
-  throw new Error("TELEGRAM_CHANNEL_ID is not a valid number");
-} else {
-  CHANNEL_ID_NUMBER = parseInt(CHANNEL_ID);
+if (
+  !SupportedPublishChannels.includes(
+    process.env.CHANNEL_TYPE as SupportedPublishChannel
+  )
+) {
+  throw new Error(
+    `CHANNEL_TYPE must be one of: ${SupportedPublishChannels.join(", ")}`
+  );
+}
+
+const CHANNEL_TYPE = process.env.CHANNEL_TYPE as SupportedPublishChannel;
+
+const MAX_NEWS_ITEMS = process.env.MAX_NEWS_ITEMS
+  ? parseInt(process.env.MAX_NEWS_ITEMS)
+  : 12;
+
+// Validate required environment variables based on formatter
+if (!process.env.CHANNEL_ID) {
+  throw new Error("CHANNEL_ID is required");
 }
 
 export const handler: EventBridgeHandler<"Object Created", any, void> = async (
@@ -75,10 +88,30 @@ export const handler: EventBridgeHandler<"Object Created", any, void> = async (
 
     console.log(`Processing news data for date: ${newsData.date}`);
 
-    const formattedNews = prioritizeAndFormat(
-      newsData,
-      CONTENT_LANGUAGE,
-      "telegram"
+    // Prioritize news items
+
+    console.log(
+      `🔍 Prioritizing ${newsData.newsResponse.newsItems.length} news items`
+    );
+    const prioritizedNews = prioritizeNews(newsData.newsResponse.newsItems)
+      .slice(0, MAX_NEWS_ITEMS)
+      .filter((item) => item.importanceScore > 4000);
+
+    console.log(
+      `After prioritizing, ${prioritizedNews.length} news items remain`
+    );
+
+    const newsDataWithPrioritizedNews = {
+      ...newsData,
+      newsResponse: { ...newsData.newsResponse, newsItems: prioritizedNews },
+    };
+
+    // Create publisher instance using factory
+    const publisher = createPublisher(CHANNEL_TYPE);
+
+    const formattedNews = publisher.formatNews(
+      newsDataWithPrioritizedNews,
+      CONTENT_LANGUAGE
     );
     if (!formattedNews) {
       console.log("No news items found, skipping posting.");
@@ -88,7 +121,7 @@ export const handler: EventBridgeHandler<"Object Created", any, void> = async (
     const mostFrequentLabel = getMostFrequentLabel(formattedNews.newsItems);
     console.log(`🔍 Most frequent label: ${mostFrequentLabel}`);
 
-    console.log("Posting summary to Telegram...");
+    console.log(`Posting summary using ${CHANNEL_TYPE} formatter...`);
 
     // Get the pre-composed banner from S3
     const bannerKey = `composedBanners/${CONTENT_LANGUAGE}/${mostFrequentLabel}.jpg`;
@@ -127,18 +160,25 @@ export const handler: EventBridgeHandler<"Object Created", any, void> = async (
       newsData.date
     );
 
-    const user = new TelegramUser();
-    await user.login();
-    await user.sendPhotoToChannel(CHANNEL_ID_NUMBER, banner, {
-      caption: formattedNews.message,
-      parseMode: "html",
-      silent: false,
-    });
-    await user.logout();
+    try {
+      await publisher.setup();
 
-    console.log("Successfully posted summary to Telegram");
+      // Publish using the unified interface
+      const postId = await publisher.publishNews(
+        process.env.CHANNEL_ID!,
+        banner,
+        formattedNews.message
+      );
+
+      console.log(
+        `Successfully posted summary to ${CHANNEL_TYPE}. Post ID: ${postId}`
+      );
+    } finally {
+      // Ensure cleanup happens regardless of success/failure
+      await publisher.destroy();
+    }
   } catch (error) {
-    console.error("Error in PostToTelegram function:", error);
+    console.error("Error in Publish function:", error);
     throw error;
   }
 };

--- a/src/publishers/AbstractPublisher.ts
+++ b/src/publishers/AbstractPublisher.ts
@@ -1,0 +1,42 @@
+import { ContentLanguage, FormattedNewsData, ProcessedNews } from "../types";
+
+export abstract class AbstractPublisher {
+  /**
+   * Setup method called before taking any action
+   * - For Telegram: Logs in the client
+   * - For Facebook: No-op (stateless HTTP requests)
+   * @returns Promise<void>
+   */
+  abstract setup(): Promise<void>;
+  /**
+   * Publishes news content with a banner image to the specified channel
+   * @param channelId - The channel/page ID to publish to
+   * @param banner - The banner image as a Buffer
+   * @param text - The formatted news text content
+   * @returns Promise<string> - The ID of the created post
+   */
+  abstract publishNews(
+    channelId: string,
+    banner: Buffer,
+    text: string
+  ): Promise<string>;
+
+  /**
+   * Cleanup method called after publishing
+   * - For Telegram: Disconnects the client
+   * - For Facebook: No-op (stateless HTTP requests)
+   * @returns Promise<void>
+   */
+  abstract destroy(): Promise<void>;
+
+  /**
+   * Formats the news data for the publisher
+   * @param newsData - The news data to format
+   * @param language - The language of the news data
+   * @returns Formatted news data
+   */
+  abstract formatNews(
+    newsData: ProcessedNews,
+    language: ContentLanguage
+  ): FormattedNewsData;
+}

--- a/src/publishers/createPublisher.ts
+++ b/src/publishers/createPublisher.ts
@@ -1,0 +1,19 @@
+import { AbstractPublisher } from "./AbstractPublisher";
+import { TelegramUser } from "../telegram/user";
+import { FacebookPage } from "../facebook/facebookPage";
+import { SupportedPublishChannel } from "../types";
+
+export function createPublisher(
+  channel: SupportedPublishChannel
+): AbstractPublisher {
+  switch (channel) {
+    case "telegram":
+      return new TelegramUser();
+
+    case "facebook":
+      return new FacebookPage();
+
+    default:
+      throw new Error(`Unsupported channel: ${channel}`);
+  }
+}

--- a/src/publishers/index.ts
+++ b/src/publishers/index.ts
@@ -1,0 +1,2 @@
+export * from "./createPublisher";
+export * from "./AbstractPublisher";

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,6 +98,10 @@ export const AvailableFormatters = ["telegram"] as const;
 
 export type AvailableFormatter = (typeof AvailableFormatters)[number];
 
+export const SupportedPublishChannels = ["telegram", "facebook"] as const;
+
+export type SupportedPublishChannel = (typeof SupportedPublishChannels)[number];
+
 export type FormattedNewsData = {
   message: string;
   newsItems: NewsItem[];

--- a/template.yml
+++ b/template.yml
@@ -32,6 +32,19 @@ Parameters:
   TelegramChannelIdArabic:
     Type: String
     Description: Telegram channel ID for Arabic posts
+  FacebookPageIdEnglish:
+    Type: String
+    Description: Facebook page ID for English posts
+    Default: ""
+  FacebookPageIdArabic:
+    Type: String
+    Description: Facebook page ID for Arabic posts
+    Default: ""
+  FacebookAccessToken:
+    Type: String
+    NoEcho: true
+    Description: Facebook access token for posting
+    Default: ""
 
 Resources:
   # S3 Bucket for storing news data between Lambda functions
@@ -153,11 +166,11 @@ Resources:
                   key:
                     - prefix: "summarized-news/"
 
-  PostToTelegramEnglishFunction:
+  PublishToTelegramEnglishFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./lambda/PostToTelegram
-      Handler: PostToTelegram.handler
+      CodeUri: ./lambda/Publish
+      Handler: Publish.handler
       Timeout: 60
       MemorySize: 512
       Runtime: nodejs22.x
@@ -176,11 +189,12 @@ Resources:
           NODE_ENV: production
           IS_LAMBDA: "true"
           CONTENT_LANGUAGE: "english"
+          CHANNEL_TYPE: "telegram"
+          CHANNEL_ID: !Ref TelegramChannelIdEnglish
           FONTCONFIG_PATH: /opt/etc/fonts
           TELEGRAM_API_ID: !Ref TelegramApiId
           TELEGRAM_API_HASH: !Ref TelegramApiHash
           SESSION_STRING: !Ref SessionString
-          TELEGRAM_CHANNEL_ID: !Ref TelegramChannelIdEnglish
       Events:
         FromEventBridge:
           Type: EventBridgeRule
@@ -195,11 +209,11 @@ Resources:
                   key:
                     - prefix: "deduplicated-news/"
 
-  PostToTelegramArabicFunction:
+  PublishToTelegramArabicFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./lambda/PostToTelegram
-      Handler: PostToTelegram.handler
+      CodeUri: ./lambda/Publish
+      Handler: Publish.handler
       Timeout: 60
       MemorySize: 512
       Runtime: nodejs22.x
@@ -218,11 +232,94 @@ Resources:
           NODE_ENV: production
           IS_LAMBDA: "true"
           CONTENT_LANGUAGE: "arabic"
+          CHANNEL_TYPE: "telegram"
+          CHANNEL_ID: !Ref TelegramChannelIdArabic
           FONTCONFIG_PATH: /opt/etc/fonts
           TELEGRAM_API_ID: !Ref TelegramApiId
           TELEGRAM_API_HASH: !Ref TelegramApiHash
           SESSION_STRING: !Ref SessionString
-          TELEGRAM_CHANNEL_ID: !Ref TelegramChannelIdArabic
+      Events:
+        FromEventBridge:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source: ["aws.s3"]
+              detail-type: ["Object Created"]
+              detail:
+                bucket:
+                  name: [!Ref NewsDataBucket]
+                object:
+                  key:
+                    - prefix: "deduplicated-news/"
+
+  PublishToFacebookEnglishFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./lambda/Publish
+      Handler: Publish.handler
+      Timeout: 60
+      MemorySize: 512
+      Runtime: nodejs22.x
+      Architectures:
+        - arm64
+      Layers:
+        - arn:aws:lambda:us-east-1:347599033421:layer:amazon_linux_fonts:1
+        - arn:aws:lambda:us-east-1:347599033421:layer:stix-fonts:1
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - S3ReadPolicy:
+            BucketName: !Ref NewsDataBucket
+      Environment:
+        Variables:
+          NODE_OPTIONS: --enable-source-maps
+          NODE_ENV: production
+          IS_LAMBDA: "true"
+          CONTENT_LANGUAGE: "english"
+          CHANNEL_TYPE: "facebook"
+          CHANNEL_ID: !Ref FacebookPageIdEnglish
+          FONTCONFIG_PATH: /opt/etc/fonts
+          FACEBOOK_ACCESS_TOKEN: !Ref FacebookAccessToken
+      Events:
+        FromEventBridge:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source: ["aws.s3"]
+              detail-type: ["Object Created"]
+              detail:
+                bucket:
+                  name: [!Ref NewsDataBucket]
+                object:
+                  key:
+                    - prefix: "deduplicated-news/"
+
+  PublishToFacebookArabicFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./lambda/Publish
+      Handler: Publish.handler
+      Timeout: 60
+      MemorySize: 512
+      Runtime: nodejs22.x
+      Architectures:
+        - arm64
+      Layers:
+        - arn:aws:lambda:us-east-1:347599033421:layer:amazon_linux_fonts:1
+        - arn:aws:lambda:us-east-1:347599033421:layer:stix-fonts:1
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - S3ReadPolicy:
+            BucketName: !Ref NewsDataBucket
+      Environment:
+        Variables:
+          NODE_OPTIONS: --enable-source-maps
+          NODE_ENV: production
+          IS_LAMBDA: "true"
+          CONTENT_LANGUAGE: "arabic"
+          CHANNEL_TYPE: "facebook"
+          CHANNEL_ID: !Ref FacebookPageIdArabic
+          FONTCONFIG_PATH: /opt/etc/fonts
+          FACEBOOK_ACCESS_TOKEN: !Ref FacebookAccessToken
       Events:
         FromEventBridge:
           Type: EventBridgeRule


### PR DESCRIPTION
- Refactor PostToTelegram to generic Publish Lambda handler
- Create AbstractPublisher base class for unified publishing interface
- Implement FacebookPage publisher with photo and text posting
- Move Telegram publishing logic to TelegramUser class extending AbstractPublisher
- Add factory pattern (createPublisher) for publisher instantiation
- Extract emoji utilities to separate module for reuse
- Export formatting utilities (Strings, measureTelegramRenderedHtml) from formatting index
- Update SAM template with 4 new publish functions (Telegram/Facebook × English/Arabic)
- Add Facebook-specific environment variables and configuration parameters
- Rename PostToTelegram.ts to Publish.ts for platform-agnostic handler